### PR TITLE
Limit username length and improve leaderboard responsiveness

### DIFF
--- a/app/Http/Controllers/Auth/RegisteredUserController.php
+++ b/app/Http/Controllers/Auth/RegisteredUserController.php
@@ -31,7 +31,7 @@ class RegisteredUserController extends Controller
     public function store(Request $request): RedirectResponse
     {
         $request->validate([
-            'name' => ['required', 'string', 'max:255', 'unique:'.User::class],
+            'name' => ['required', 'string', 'max:20', 'unique:'.User::class],
             'email' => ['required', 'string', 'email', 'max:255', 'unique:'.User::class],
             'password' => ['required', 'confirmed', Rules\Password::defaults()],
         ]);

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -5,7 +5,7 @@
         <!-- Name -->
         <div>
             <x-input-label for="name" :value="__('Name')" />
-            <x-text-input id="name" class="block mt-1 w-full" type="text" name="name" :value="old('name')" required autofocus autocomplete="name" />
+            <x-text-input id="name" class="block mt-1 w-full" type="text" name="name" :value="old('name')" required autofocus autocomplete="name" maxlength="20" />
             <x-input-error :messages="$errors->get('name')" class="mt-2" />
         </div>
 

--- a/resources/views/leaderboard.blade.php
+++ b/resources/views/leaderboard.blade.php
@@ -6,54 +6,55 @@
     </x-slot>
 
     <div class="max-w-7xl mx-auto sm:px-6 lg:px-8 flex justify-center pt-12">
-        <div class="bg-white dark:bg-zinc-900 overflow-hidden shadow-xl sm:rounded-xl">
+        <div class="bg-white dark:bg-zinc-900 overflow-hidden shadow-xl rounded-xl">
             <div class="p-6 text-gray-900 dark:text-gray-100 text-xl text-center">
 
                 Your score: {{ $userScore }} @if($userPosition > 0 && $userScore > 0)
                     Your position: {{ $userPosition }} / {{ $users->count() }}
                 @endif
                 @if($userPosition === 1 && $userScore > 0)
-                    <div class="text-4xl">🏆 You are the leader 🏆</div>
+                    <div class="text-2xl md:text:4xl lg:text-4xl">🏆 You are the leader 🏆</div>
                 @endif
                 @if($userScore === 0)
-                    <div class="text-4xl">Solve at least one task to appear in leaderboard</div>
+                    <div class="text-2xl md:text:4xl lg:text-4xl">Solve at least one task to appear in leaderboard</div>
                 @endif
             </div>
         </div>
     </div>
 
-    <div class="flex justify-center text-white text-7xl mt-3">Top players</div>
+    <div class="flex justify-center text-white text-5xl md:text-7xl lg:text-7xl mt-3">Top players</div>
     <div class="flex justify-center">
-        <div class="text-5xl text-white mt-8">
+        <div class="text-3xl md:text-4xl lg:text-5xl text-white mt-8">
             <div class="text-center">
                 @if($users->count() === 0)
                     <div class="text-4xl">No entries yet</div>
                 @else
-                <table class="mt-4">
-                    <tr>
-                        <th class="p-4">Position</th>
-                        <th class="p-4">Name</th>
-                        <th class="p-4">Score</th>
-                        <th class="p-4">Last task solved</th>
-                    </tr>
-                    @foreach($users as $user)
-                        @php
-                            $index = $loop->index + 1;
-                        @endphp
-                        <tr class="{{ $user->id === Auth::id() ? 'bg-zinc-900 rounded-xl p-4 mb-4 shadow-xl' : 'mb-2' }}">
-                            <td class="p-4">{{ $index }}</td>
-                            <td class="p-4">{{ $user->name }}</td>
-                            <td class="p-4">{{ $user->leaderboard->score }}</td>
-                            <td class="p-4">{{ $user->leaderboard->updated_at->diffForHumans() }}</td>
-                        </tr>
-                    @endforeach
-                </table>
+                    <div class="overflow-x-auto">
+                        <table class="mt-4 text-xl md:text-3xl lg:text-5xl">
+                            <tr>
+                                <th class="p-1 lg:p-4 md:p-3">Position</th>
+                                <th class="p-1 lg:p-4 md:p-3">Name</th>
+                                <th class="p-1 lg:p-4 md:p-3">Score</th>
+                                <th class="p-1 lg:p-4 md:p-3">Last task solved</th>
+                            </tr>
+                            @foreach($users as $user)
+                                @php
+                                    $index = $loop->index + 1;
+                                @endphp
+                                <tr class="{{ $user->id === Auth::id() ? 'bg-zinc-900 rounded-xl p-4 mb-4 shadow-xl' : 'mb-2' }}">
+                                    <td class="p-1 lg:p-4 md:p-3">{{ $index }}</td>
+                                    <td class="p-1 lg:p-4 md:p-3 break-all">{{ $user->name }}</td>
+                                    <td class="p-1 lg:p-4 md:p-3">{{ $user->leaderboard->score }}</td>
+                                    <td class="p-1 lg:p-4 md:p-3">{{ $user->leaderboard->updated_at->diffForHumans() }}</td>
+                                </tr>
+                            @endforeach
+                        </table>
+                    </div>
                 @endif
 
             </div>
         </div>
     </div>
-
 
 
 </x-app-layout>


### PR DESCRIPTION
This commit sets a maximum length of 20 characters for the username field during the registration process, and also refactoring the leaderboard view to be more responsive. The username length limit is designed to prevent UX issues with extremely long names. The leaderboard view responsiveness has been improved by adding responsive breakpoints so the text size adjusts better on different screen sizes, thus enhancing its readability across all devices.