### PR TITLE
Add print functionality to leaderboard

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -1,3 +1,31 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+
+/* css used for printing of leaderboard */
+@media print {
+    body * {
+        visibility: hidden;
+    }
+
+    #printTable, #printTable * {
+        visibility: visible;
+    }
+
+    #printTable {
+        position: absolute;
+        left: 0;
+        top: 0;
+        color: black;
+    }
+
+    #printTable tr.bg-zinc-900 {
+        background-color: transparent !important;
+        box-shadow: none !important;
+    }
+    #printTable td, th {
+        border: 1px solid #000 !important;
+        padding: 10px !important;
+    }
+}

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -5,3 +5,8 @@ import Alpine from 'alpinejs';
 window.Alpine = Alpine;
 
 Alpine.start();
+
+// Button used to print the leaderboard
+document.getElementById('printButton').addEventListener('click', function() {
+    window.print();
+});

--- a/resources/views/leaderboard.blade.php
+++ b/resources/views/leaderboard.blade.php
@@ -24,13 +24,16 @@
 
     <div class="flex justify-center text-white text-5xl md:text-7xl lg:text-7xl mt-3">Top players</div>
     <div class="flex justify-center">
-        <div class="text-3xl md:text-4xl lg:text-5xl text-white mt-8 mb-96">
+        <button id="printButton" class="mt-8 btn btn-outline">Print leaderboard 🖨️</button>
+    </div>
+    <div class="flex justify-center">
+        <div class="text-3xl md:text-4xl lg:text-5xl text-white mt-6 mb-96">
             <div class="text-center">
                 @if($users->count() === 0)
                     <div class="text-4xl">No entries yet</div>
                 @else
                     <div class="overflow-x-auto">
-                        <table class="mt-4 text-xl md:text-3xl lg:text-5xl">
+                        <table id="printTable" class="mt-4 text-xl md:text-3xl lg:text-5xl">
                             <tr>
                                 <th class="p-1 lg:p-4 md:p-3">Position</th>
                                 <th class="p-1 lg:p-4 md:p-3">Name</th>
@@ -51,7 +54,6 @@
                         </table>
                     </div>
                 @endif
-
             </div>
         </div>
     </div>


### PR DESCRIPTION
This commit adds a new feature that allows users to print the leaderboard directly from the application. This was achieved by adding a click event listener to a new 'Print leaderboard' button, which triggers the browser's window.print() function. CSS styles for the @media print query were also added to ensure the leaderboard prints correctly and clearly, by making only the leaderboard table visible during printing, absolute positioning the table to the top-left, and ensuring high contrast black text. Changes in leaderboard.blade.php includes the addition of the print button and id assignment to the leaderboard table for targeted styling during print.